### PR TITLE
Add Dockerfile and usange examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN yarn build
 FROM alpine:3.19.1@sha256:15c46ced65c6abed6a27472a7904b04273e9a8091a5627badd6ff016ab073171
 
 ARG VERSION="1.1.4"
+ARG INSTALL_LXML=""
+ARG ENABLE_FULL_TEXT_SEARCH=""
+ARG ENABLE_MORPHOLOGY_ANALYSIS=""
+ARG MORPHOLOGY_ANALYSIS_LIBRARY="sibel"
+ARG ENABLE_CHINESE_CONVERSION=""
 
 ENV HOST="0.0.0.0"
 ENV PORT="2628"
@@ -42,10 +47,11 @@ COPY --chown=silverdict:silverdict ./server/requirements.txt /silverdict/server/
 
 # Install dependencies
 RUN apk update && \
-  apk add --no-cache python3 libxslt && \
-  apk add --no-cache --virtual .build-deps python3-dev py3-pip gcc g++ lzo-dev libxml2-dev libxslt-dev && \
+  apk add --no-cache python3 ${INSTALL_LXML:+libxslt libxml2} ${ENABLE_FULL_TEXT_SEARCH:+xapian-bindings-python3} ${ENABLE_CHINESE_CONVERSION:+opencc} && \
+  apk add --no-cache --virtual .build-deps python3-dev py3-pip gcc g++ lzo-dev ${INSTALL_LXML:+libxml2-dev libxslt-dev} ${ENABLE_MORPHOLOGY_ANALYSIS:+hunspell-dev icu-dev} && \
   python3 -m venv $VIRTUAL_ENV && \
   pip install --no-cache-dir -r requirements.txt && \
+  pip install pip ${INSTALL_LXML:+lxml} ${ENABLE_MORPHOLOGY_ANALYSIS:+${MORPHOLOGY_ANALYSIS_LIBRARY}} ${ENABLE_CHINESE_CONVERSION:+opencc} && \
   apk del .build-deps
 
 # Copy server and built frontend from the frontend-builder stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,16 +45,16 @@ COPY --chown=silverdict:silverdict ./server/requirements.txt /silverdict/server/
 
 # Install dependencies
 RUN apk update && \
-  apk add --no-cache python3 lzo py3-yaml ${ENABLE_FULL_TEXT_SEARCH:+xapian-bindings-python3 py3-lxml} ${ENABLE_MORPHOLOGY_ANALYSIS:+libhunspell} && \
+  apk add --no-cache python3 lzo py3-yaml py3-xxhash py3-flask py3-flask-cors py3-waitress py3-requests ${ENABLE_FULL_TEXT_SEARCH:+xapian-bindings-python3 py3-lxml} ${ENABLE_MORPHOLOGY_ANALYSIS:+libhunspell} && \
   apk add --no-cache --virtual .build-deps python3-dev py3-pip gcc g++ lzo-dev ${ENABLE_MORPHOLOGY_ANALYSIS:+hunspell-dev} ${ENABLE_CHINESE_CONVERSION:+make cmake doxygen} && \
   python3 -m venv $VIRTUAL_ENV --system-site-packages && \
   pip install --no-cache-dir -r requirements.txt && \
-  if [ "$ENABLE_MORPHOLOGY_ANALYSIS" = "true" ]; then \
+  if [ "x$ENABLE_MORPHOLOGY_ANALYSIS" = "xtrue" ]; then \
     ln -s /usr/include/hunspell/* /usr/include/ && \
     ln -s /usr/lib/libhunspell-*.so /usr/lib/libhunspell.so && \
     pip install hunspell; \
   fi && \
-  if [ "$ENABLE_CHINESE_CONVERSION" = "true" ]; then \
+  if [ "x$ENABLE_CHINESE_CONVERSION" = "xtrue" ]; then \
     wget https://github.com/BYVoid/OpenCC/archive/refs/tags/ver.1.1.7.tar.gz && \
     tar xzf ver.1.1.7.tar.gz && \
     cd OpenCC-ver.1.1.7 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Stage 1: Frontend Builder
+FROM node:lts-alpine3.19@sha256:ef3f47741e161900ddd07addcaca7e76534a9205e4cd73b2ed091ba339004a75 as frontend-builder
+
+WORKDIR /silverdict/client
+
+# Copy only package.json and yarn.lock to leverage Docker cache layer
+COPY ./client/package.json ./client/yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# Copy the entire client directory
+COPY client ./
+
+# Build the frontend
+RUN yarn build
+
+# Stage 2: Production Environment
+FROM alpine:3.19.1@sha256:15c46ced65c6abed6a27472a7904b04273e9a8091a5627badd6ff016ab073171
+
+ARG VERSION="1.1.4"
+
+ENV HOST="0.0.0.0"
+ENV PORT="2628"
+
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+LABEL org.opencontainers.image.title="SilverDict"
+LABEL org.opencontainers.image.description="Web-Based Alternative to GoldenDict"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.authors="Yi Xing <blandilyte@gmail.com>"
+LABEL org.opencontainers.image.url="https://crissium.github.io/SilverDict"
+LABEL org.opencontainers.image.source="https://github.com/Crissium/SilverDict"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+
+WORKDIR /silverdict/server
+
+RUN adduser -D silverdict
+
+COPY --chown=silverdict:silverdict ./server/requirements.txt /silverdict/server/requirements.txt
+
+# Install dependencies
+RUN apk update && \
+  apk add --no-cache python3 libxslt && \
+  apk add --no-cache --virtual .build-deps python3-dev py3-pip gcc g++ lzo-dev libxml2-dev libxslt-dev && \
+  python3 -m venv $VIRTUAL_ENV && \
+  pip install --no-cache-dir -r requirements.txt && \
+  apk del .build-deps
+
+# Copy server and built frontend from the frontend-builder stage
+COPY --chown=silverdict:silverdict ./server /silverdict/server
+COPY --from=frontend-builder --chown=silverdict:silverdict /silverdict/client/build /silverdict/server/build
+
+# Switch to non-root user
+USER silverdict
+
+# Expose the required port
+EXPOSE "${PORT}/tcp"
+
+# Entry point for the application
+ENTRYPOINT python server.py "${HOST}:${PORT}"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ I recommend nginx if you plan to deploy SilverDict to a server. Run `yarn build`
 
 Assuming your distribution uses systemd, you can refer to the provided sample systemd [config](/silverdict.service) and run the script as a service.
 
+#### Docker Deployment
+
+#### Build Docker Image from Source
+
+```bash
+docker build --tag silverdict git@github.com:Crissium/SilverDict.git
+docker run --publish 2628:2628 --volume ${PATH_TO_DICTIONARIES}:/home/silverdict/.silverdict/ --name silverdict silverdict
+```
+
+`${PATH_TO_DICTIONARIES}` is the path where settings and dictionaries are stored. It should be writable to other users or should be owned by the same user and user group as in docker. The default path to scan for dictionaries is `${PATH_TO_DICTIONARIES}/source`
+
+Or use Docker Compose: Edit `docker-compose.yml` and
+
+```bash
+docker compose up -d
+```
+
+#### Use Ready-Built Docker Image
+
+To be done. 
+
 ## Contributing
 
 - Start with an item in the roadmap, or open an issue to discuss your ideas. Please notify me if you are working on something to avoid duplicated efforts. I myself dislike enforcing a coding style, but please use descriptive, verbose variable names and UTF-8 encoding, LF line endings, and indent with tabs.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ xxhash # for v3 MDict
 dsl2html # for DSL
 xdxf2html # for XDXF-formatted StarDicts
 requests # for auto-update
+lxml # for XML processing
 ```
 
 The packages [`dsl2html`](https://github.com/Crissium/python-dsl) and [`xdxf2html`](https://github.com/Crissium/python-xdxf2html) are mine, and could potentially be used by other projects.
@@ -72,7 +73,7 @@ In order to enable the feature of morphology analysis, you need to place the Hun
 
 In order to enable the feature of Chinese conversion, you need to install the Python package `opencc`.
 
-To use full-text search, please install `xapian`, optionally also `lxml`.
+To use full-text search, please install `xapian`.
 
 #### Note about the non pure Python dependencies
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Assuming your distribution uses systemd, you can refer to the provided sample sy
 #### Build Docker Image from Source
 
 ```bash
-docker build --tag silverdict git@github.com:Crissium/SilverDict.git
+docker build --tag silverdict https://github.com/Crissium/SilverDict.git
 docker run --publish 2628:2628 --volume ${PATH_TO_DICTIONARIES}:/home/silverdict/.silverdict/ --name silverdict silverdict
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,26 @@ Assuming your distribution uses systemd, you can refer to the provided sample sy
 
 ```bash
 docker build --tag silverdict https://github.com/Crissium/SilverDict.git
-docker run --publish 2628:2628 --volume ${PATH_TO_DICTIONARIES}:/home/silverdict/.silverdict/ --name silverdict silverdict
+docker run --rm --publish 2628:2628 --volume ${PATH_TO_DICTIONARIES}:/home/silverdict/.silverdict/ --name silverdict silverdict
 ```
 
-`${PATH_TO_DICTIONARIES}` is the path where settings and dictionaries are stored. It should be writable to other users or should be owned by the same user and user group as in docker. The default path to scan for dictionaries is `${PATH_TO_DICTIONARIES}/source`
+`${PATH_TO_DICTIONARIES}` is the path where settings and dictionaries are stored. It should be writable to other users or should be owned by the same user and user group as in docker. The default path to scan is `${PATH_TO_DICTIONARIES}/source` for dictionaries and `${PATH_TO_DICTIONARIES}/hunspell` for spellchecking libraries (if enabled).
+
+When building the Docker image, optional features can be enabled by passing `--build-arg`. For example, if you want to enable full text search: 
+
+```bash
+docker build --tag silverdict --build-arg INSTALL_LXML=1 https://github.com/Crissium/SilverDict.git
+```
+
+Available arguments are:
+
+| Argument                    | value              | default |
+| --------------------------- | ------------------ | ------- |
+| INSTALL_LXML                | 1 or empty         | empty   |
+| ENABLE_FULL_TEXT_SEARCH     | 1 or empty         | empty   |
+| ENABLE_MORPHOLOGY_ANALYSIS  | 1 or empty         | empty   |
+| MORPHOLOGY_ANALYSIS_LIBRARY | sibel or hunspell  | sibel   |
+| ENABLE_CHINESE_CONVERSION   | 1 or empty         | empty   |
 
 Or use Docker Compose: Edit `docker-compose.yml` and
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ xxhash # for v3 MDict
 dsl2html # for DSL
 xdxf2html # for XDXF-formatted StarDicts
 requests # for auto-update
-lxml # for XML processing
 ```
 
 The packages [`dsl2html`](https://github.com/Crissium/python-dsl) and [`xdxf2html`](https://github.com/Crissium/python-xdxf2html) are mine, and could potentially be used by other projects.
@@ -73,7 +72,7 @@ In order to enable the feature of morphology analysis, you need to place the Hun
 
 In order to enable the feature of Chinese conversion, you need to install the Python package `opencc`.
 
-To use full-text search, please install `xapian`.
+To use full-text search, please install `xapian`, optionally also `lxml`.
 
 #### Note about the non pure Python dependencies
 

--- a/client/package.json
+++ b/client/package.json
@@ -31,5 +31,8 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.4.5",
 		"vite": "^5.0.8"
+	},
+	"resolutions": {
+		"rollup": "npm:@rollup/wasm-node"
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   silverdict:
     build: .
     volumes:
-      - ./dictionaries:/home/silverdict/.silverdict/
+      - ./dictionaries/:/home/silverdict/.silverdict/
+      # - /path/to/cache/:/home/silverdict/.cache/SilverDict/ # Optional mounting of cache
     restart: unless-stopped
     ports:
       - 2628:2628

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  silverdict:
+    build: .
+    volumes:
+      - ./dictionaries:/home/silverdict/.silverdict/
+    restart: unless-stopped
+    ports:
+      - 2628:2628

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,3 +8,4 @@ xxhash>=3.2.0
 dsl2html>=0.1.2
 xdxf2html>=0.1.0
 requests>=2.31.0
+lxml>=5.1.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,4 +8,3 @@ xxhash>=3.2.0
 dsl2html>=0.1.2
 xdxf2html>=0.1.0
 requests>=2.31.0
-lxml>=5.1.0


### PR DESCRIPTION
What I did:

- Adding `lxml` in `./server/requirements.txt`
- Adding `npm:@rollup/wasm-node` override in `./client/package.json`
- Adding `Dockerfile` for building Docker image and example usages

Because of the compilation of `lxml`, etc, the building time of this docker image is quite long. I suggest publishing ready-built image to [Docker Hub](https://docs.docker.com/guides/walkthroughs/publish-your-image/) or [Github Docker Registory](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images).